### PR TITLE
Add duplicate detection for new task

### DIFF
--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -1,4 +1,5 @@
 T | 1 | jump around
 D | 0 | assignment | 2020-03-03
 T | 0 | dishes
-E | 0 | exams | 2023-10-10 | 2023-11-10
+E | 1 | exams | 2023-10-10 | 2023-11-10
+T | 0 | dish

--- a/src/main/java/robert/command/AddCommand.java
+++ b/src/main/java/robert/command/AddCommand.java
@@ -72,6 +72,11 @@ public class AddCommand extends Command {
      */
     @Override
     public String execute(TaskList tasks, Storage storage) throws RobertException {
+        if (tasks.isInTaskList(this.task.getDescription())) {
+            return "Hmm... You already have this task in your list.\n" +
+                    "Check your list of tasks by using the 'list' command.";
+        }
+
         tasks.addTask(this.task);
         return "Got it. I have added this task:\n  " + this.task
                 + "\nNow you have " + tasks.getTaskCount() + " "

--- a/src/main/java/robert/task/TaskList.java
+++ b/src/main/java/robert/task/TaskList.java
@@ -117,6 +117,21 @@ public class TaskList implements Iterable<Task> {
         this.tasks = new ArrayList<>();
     }
 
+    /**
+     * Checks whether a task exist in the task list.
+     *
+     * @param description the exact description of the task to be identified.
+     * @return boolean on whether the task is found.
+     */
+    public boolean isInTaskList(String description) {
+        for (Task task : this.tasks) {
+            if (task.getDescription().equals(description)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     @Override
     public Iterator<Task> iterator() {

--- a/src/main/resources/view/DialogBox.fxml
+++ b/src/main/resources/view/DialogBox.fxml
@@ -4,17 +4,19 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.text.TextFlow?>
 
-<fx:root alignment="TOP_RIGHT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefWidth="700.0" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root alignment="TOP_RIGHT" maxWidth="1.7976931348623157E308" prefWidth="700.0" type="javafx.scene.layout.HBox" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <Label fx:id="dialog" style="-fx-background-color: #CCCCCC; -fx-background-radius: 5; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.5), 10, 0, 0, 0); -fx-font-size: large;" text="Label" wrapText="true">
-         <HBox.margin>
-            <Insets left="20.0" right="20.0" />
-         </HBox.margin>
-         <padding>
-            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-         </padding>
-      </Label>
+      <TextFlow>
+         <children>
+              <Label fx:id="dialog" style="-fx-background-color: #CCCCCC; -fx-background-radius: 5; -fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.5), 10, 0, 0, 0); -fx-font-size: large;" text="Label">
+               <padding>
+                  <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+               </padding>
+            </Label>
+         </children>
+      </TextFlow>
         <ImageView fx:id="displayPicture" fitHeight="120.0" fitWidth="120.0" pickOnBounds="true" preserveRatio="true" style="-fx-effect: dropshadow(three-pass-box, rgba(0,0,0,0.5), 10, 0, 0, 0);">
          <HBox.margin>
             <Insets left="10.0" right="10.0" />


### PR DESCRIPTION
There may be instances where users mistakenly input the same tasks multiple times. With duplicates in the task list, it may cause confusion for the user, especially when there are no dates associated to it (e.g. todo tasks).

Let's add a duplicate detection method during the addition of a new task.

This will prevent tasks of duplicate descriptions being in the list at the same time.